### PR TITLE
Add first cut of concentration models.

### DIFF
--- a/doc/nml.org
+++ b/doc/nml.org
@@ -850,3 +850,86 @@ optional. Alternatively it seems (?) we can address using ~pop/<id>/Cell~
     <explicitInput target="hhpop[0]" input="pulseGen2"/>
 </network>
 #+end_src
+
+* Concentration Models
+First, duplicate the ~ComponentType~ for reference with the usual simplifications
+#+begin_src xml
+<ComponentType name="concentrationModel">
+    <Exposure name="concentration" dimension="concentration"/>
+    <Exposure name="extConcentration" dimension="concentration"/>
+
+    <Requirement name="surfaceArea" dimension="area"/>
+    <Requirement name="initialConcentration" dimension="concentration"/>
+    <Requirement name="initialExtConcentration" dimension="concentration"/>
+
+    <Text name="ion"/>
+
+    <Dynamics>
+        <StateVariable name="concentration" exposure="concentration" dimension="concentration"/>
+        <StateVariable name="extConcentration" exposure="extConcentration" dimension="concentration"/>
+        <OnStart>
+            <StateAssignment variable="concentration" value="initialConcentration"/>
+            <StateAssignment variable="extConcentration" value="initialExtConcentration"/>
+        </OnStart>
+    </Dynamics>
+</ComponentType>
+
+
+<ComponentType name="decayingPoolConcentrationModel" extends="concentrationModel">
+    <Parameter name="restingConc" dimension="concentration"/>
+    <Parameter name="decayConstant" dimension="time"/>
+    <Parameter name="shellThickness" dimension="length"/>
+
+    <Constant name="Faraday" dimension="charge_per_mole" value="96485.3C_per_mol"/>
+    <Constant name="AREA_SCALE" dimension="area" value="1m2"/>
+    <Constant name="LENGTH_SCALE" dimension="length" value="1m"/>
+
+    <Requirement name="iCa" dimension="current"/>
+
+    <Dynamics>
+        <StateVariable name="concentration" exposure="concentration" dimension="concentration"/>
+        <StateVariable name="extConcentration" exposure="extConcentration" dimension="concentration"/>
+
+        <DerivedVariable name="effectiveRadius" dimension="length" value="LENGTH_SCALE * sqrt(surfaceArea/(AREA_SCALE * (4 * 3.14159)))"/>
+        <DerivedVariable name="innerRadius" dimension="length" value="effectiveRadius - shellThickness"/>
+
+        <DerivedVariable name="shellVolume" dimension="volume" value="(4 * (effectiveRadius * effectiveRadius * effectiveRadius) * 3.14159 / 3) - (4 * (innerRadius * innerRadius * innerRadius) * 3.14159 / 3)"/>
+
+        <TimeDerivative variable="concentration" value="iCa / (2 * Faraday * shellVolume) - ((concentration - restingConc) / decayConstant)"/>
+
+        <OnStart>
+            <StateAssignment variable="concentration" value="initialConcentration"/>
+            <StateAssignment variable="extConcentration" value="initialExtConcentration"/>
+        </OnStart>
+
+        <OnCondition test="concentration .lt. 0">
+            <StateAssignment variable="concentration" value="0"/>
+        </OnCondition>
+    </Dynamics>
+</ComponentType>
+
+<ComponentType name="fixedFactorConcentrationModel" extends="concentrationModel">
+    <Parameter name="restingConc" dimension="concentration"/>
+    <Parameter name="decayConstant" dimension="time"/>
+    <Parameter name="rho" dimension="rho_factor"/>
+
+    <Requirement name="iCa" dimension="current"/>
+    <Requirement name="surfaceArea" dimension="area"/>
+
+    <Dynamics>
+        <StateVariable name="concentration" exposure="concentration" dimension="concentration"/>
+        <StateVariable name="extConcentration" exposure="extConcentration" dimension="concentration"/>
+
+        <TimeDerivative variable="concentration" value="(iCa/surfaceArea) * rho - ((concentration - restingConc) / decayConstant)"/>
+
+        <OnStart>
+            <StateAssignment variable="concentration" value="initialConcentration"/>
+            <StateAssignment variable="extConcentration" value="initialExtConcentration"/>
+        </OnStart>
+
+        <OnCondition test="concentration .lt. 0">
+            <StateAssignment variable="concentration" value="0"/>
+        </OnCondition>
+    </Dynamics>
+</ComponentType>
+#+end_src

--- a/example/nml-conc-models.nml
+++ b/example/nml-conc-models.nml
@@ -1,0 +1,8 @@
+<neuroml xmlns="http://www.neuroml.org/schema/neuroml2"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:schemaLocation="http://www.neuroml.org/schema/neuroml2 ../Schemas/NeuroML2/NeuroML_v2beta4.xsd"
+    id="conc-models">
+
+  <decayingPoolConcentrationModel id="dpcm" ion="na" restingConc="42" decayConstant="23" shellThickness="7" />
+  <fixedFactorConcentrationModel id="ffcm" ion="na" restingConc="42" decayConstant="23" rho="7" />
+</neuroml>

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -447,7 +447,8 @@ mod parse {
 
     fn atom(input: &str) -> IResult<&str, Expr> {
         let (input, sign) = opt(delimited(space0, tag("-"), space0))(input)?;
-        let (input, result) = delimited(space0, alt((parenthised, exp, sqrt, lit, var)), space0)(input)?;
+        let (input, result) =
+            delimited(space0, alt((parenthised, exp, sqrt, lit, var)), space0)(input)?;
         if sign.is_some() {
             Ok((input, Expr::Mul(vec![Expr::F64(-1.0), result])))
         } else {

--- a/src/instance.rs
+++ b/src/instance.rs
@@ -283,7 +283,7 @@ impl Collapsed {
         let ct = &inst.component_type;
         let mut ctx = ctx.clone();
         let nm = if add_name {
-            if let Some(n) = inst.id.as_deref().or(name.as_deref()) {
+            if let Some(n) = inst.id.as_deref().or_else(|| name.as_deref()) {
                 n
             } else {
                 info!("Found node without id, setting to 'Unknown'");

--- a/src/nmodl.rs
+++ b/src/nmodl.rs
@@ -324,7 +324,10 @@ pub fn mk_nmodl(n: &Nmodl) -> Result<String> {
 
 fn nmodl_state_block(n: &Nmodl) -> Result<String> {
     if !n.state.is_empty() {
-        Ok(format!("STATE {{ {} }}\n\n", n.state.iter().cloned().collect::<Vec<_>>().join(" ")))
+        Ok(format!(
+            "STATE {{ {} }}\n\n",
+            n.state.iter().cloned().collect::<Vec<_>>().join(" ")
+        ))
     } else {
         Ok(String::new())
     }
@@ -575,9 +578,7 @@ fn ion_species(coll: &Collapsed) -> Vec<String> {
     coll.attributes
         .iter()
         .filter_map(|(k, v)| {
-            if k.ends_with("species") {
-                Some(v.as_deref().unwrap_or_default().to_string())
-            } else if k == "ion" {
+            if k.ends_with("species") || k == "ion" {
                 Some(v.as_deref().unwrap_or_default().to_string())
             } else {
                 None
@@ -777,8 +778,8 @@ pub fn to_nmodl(instance: &Instance, filter: &str) -> Result<String> {
             os.insert(xo.clone(), Stmnt::Ass(xo.clone(), Expr::Var(ec.clone())));
             n.add_outputs(&os);
             let mut is = Map::new();
-            is.insert(ic.clone(), Stmnt::Ass(ic.clone(), Expr::Var(xi.clone())));
-            is.insert(ec.clone(), Stmnt::Ass(ec.clone(), Expr::Var(xo.clone())));
+            is.insert(ic.clone(), Stmnt::Ass(ic, Expr::Var(xi)));
+            is.insert(ec.clone(), Stmnt::Ass(ec, Expr::Var(xo)));
             n.add_initials(&is);
             // Map variables iCa -> iX to compensate for NML2 mistakes
             let fix = |ex: &Expr| -> Expr {

--- a/tests/test_nmodl.rs
+++ b/tests/test_nmodl.rs
@@ -46,6 +46,7 @@ BREAKPOINT {
 NET_RECEIVE(weight) {
   g = g + 0.0005 * weight
 }
+
 "#
     );
     assert_eq!(
@@ -80,6 +81,65 @@ BREAKPOINT {
 NET_RECEIVE(weight) {
   g = g + gbase * weight
 }
+
+"#
+    );
+}
+
+#[test]
+fn simple_gap_junction() {
+    let lems = LemsFile::from(
+        &[String::from("ext/NeuroML2/NeuroML2CoreTypes")],
+        &[String::from("NeuroML2CoreTypes.xml")],
+    )
+    .unwrap();
+    let tree = Document::parse(r#"<neuroml xmlns="http://www.neuroml.org/schema/neuroml2"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:schemaLocation="http://www.neuroml.org/schema/neuroml2 ../Schemas/NeuroML2/NeuroML_v2beta4.xsd"
+    id="simple-gap-junction">
+    <gapJunction id="gj1" conductance="10pS"/>
+</neuroml>"#).unwrap();
+    let node = tree
+        .descendants()
+        .find(|n| n.has_tag_name("gapJunction"))
+        .unwrap();
+    let inst = Instance::new(&lems, &node).unwrap();
+    assert_eq!(
+        to_nmodl(&inst, "-*").unwrap(),
+        r#"NEURON {
+  JUNCTION gj1
+  NONSPECIFIC_CURRENT i
+  RANGE conductance, weight
+}
+
+PARAMETER {
+  conductance = 0.00001 (uS)
+  weight = 1
+}
+
+BREAKPOINT {
+  i = conductance * weight * (v_peer + -1 * v)
+}
+
+"#
+    );
+    assert_eq!(
+        to_nmodl(&inst, "+*").unwrap(),
+        r#"NEURON {
+  JUNCTION gj1
+  NONSPECIFIC_CURRENT i
+  RANGE conductance, weight
+}
+
+PARAMETER {
+  conductance = 0.00001 (uS)
+  weight = 1
+}
+
+BREAKPOINT {
+  i = conductance * weight * (v_peer + -1 * v)
+}
+
 "#
     );
 }


### PR DESCRIPTION
Add a rough cut of concentration models. There's no checking whether the concentration is actually written,
so we naively assume _both_ `Xi` and `Xo` are always updated. Proper analysis of the AST is needed for more.

On the other hand, this seems more like a niche case, only appearing in some concentration models, where we write out
`Xi = concentration` and `concentration is state. We could as well special case those.

Fixes #8 