### PR TITLE
Layer 5 Pyramidal Cell

### DIFF
--- a/src/acc.rs
+++ b/src/acc.rs
@@ -204,33 +204,21 @@ impl Paintable {
 
 impl Sexp for Expr {
     fn to_sexp(&self) -> String {
+        fn op_to_sexp(op: &str, args: &Vec<Expr>) -> String {
+                let mut s = "(".to_string();
+                s.push_str(op);
+                for arg in args {
+                    s.push_str(&format!(" {}", arg.to_sexp()));
+                }
+                s.push(')');
+                s
+        }
         match self {
             Expr::F64(x) => format!("{x}"),
             Expr::Var(x) => format!("{x}"),
-            Expr::Add(x) => {
-                let mut s = "(add".to_string();
-                for arg in x {
-                    s.push_str(&format!(" {}", arg.to_sexp()));
-                }
-                s.push(')');
-                s
-            },
-            Expr::Mul(x) => {
-                let mut s = "(mul".to_string();
-                for arg in x {
-                    s.push_str(&format!(" {}", arg.to_sexp()));
-                }
-                s.push(')');
-                s
-            }
-            Expr::Pow(x) => {
-                let mut s = "(pow".to_string();
-                for arg in x {
-                    s.push_str(&format!(" {}", arg.to_sexp()));
-                }
-                s.push(')');
-                s
-            }
+            Expr::Add(x) => op_to_sexp("add", x),
+            Expr::Mul(x) => op_to_sexp("mul", x),
+            Expr::Pow(x) => op_to_sexp("pow", x),
             Expr::Exp(x) => format!("(exp {})", x.to_sexp()),
             Expr::Log(x) => format!("(log {})", x.to_sexp()),
             Expr::Sqrt(x) => format!("(sqrt {})", x.to_sexp()),

--- a/src/acc.rs
+++ b/src/acc.rs
@@ -563,10 +563,11 @@ fn intra(intra: &IntracellularProperties) -> Result<Vec<Decor>> {
     for item in &intra.body {
         match &item {
             species(Species {
-                ion,
+                ion, // the neuroml standard suggests selecting on id instead of ion
                 initialConcentration,
                 initialExtConcentration,
                 segmentGroup,
+                concentrationModel,
                 ..
             }) if ion.is_some() => {
                 let ion = ion.as_deref().unwrap();
@@ -580,6 +581,12 @@ fn intra(intra: &IntracellularProperties) -> Result<Vec<Decor>> {
                     Paintable::Xo(ion.to_string(), initialExtConcentration.to_string()),
                     false,
                 ));
+                result.push(Decor::new(
+                    segmentGroup,
+                    Paintable::Mech(concentrationModel.to_string(), Map::new()),
+                    false
+                ));
+
             }
             resistivity(Resistivity {
                 value,

--- a/src/acc.rs
+++ b/src/acc.rs
@@ -583,7 +583,7 @@ fn intra(intra: &IntracellularProperties) -> Result<Vec<Decor>> {
                 ));
                 result.push(Decor::new(
                     segmentGroup,
-                    Paintable::Mech(concentrationModel.to_string(), Map::new()),
+                    Paintable::Mech(concentrationModel.to_string(), Map::from([(String::from("initialConcentration"), initialConcentration.to_string())])),
                     false
                 ));
 

--- a/src/acc.rs
+++ b/src/acc.rs
@@ -56,6 +56,9 @@ fn parse_inhomogeneous_parameters(cell: &roxmltree::Node<'_, '_>) -> Result<Map<
                 use crate::neuroml::raw::{ProximalDetails, DistalDetails};
                 use crate::neuroml::raw::InhomogeneousParameterBody::*;
                 let ihp: InhomogeneousParameter = XML::from_node(&ihp);
+                if ihp.metric != "Path Length from root" {
+                    return Err(nml2_error("Only path length from root is supported as inhomogeneous parameter metric"));
+                }
                 let mut subtract_the_minimum = false;
                 let mut normalize_end = false;
                 for elem in ihp.body {

--- a/src/acc.rs
+++ b/src/acc.rs
@@ -205,13 +205,7 @@ impl Paintable {
 impl Sexp for Expr {
     fn to_sexp(&self) -> String {
         fn op_to_sexp(op: &str, args: &Vec<Expr>) -> String {
-                let mut s = "(".to_string();
-                s.push_str(op);
-                for arg in args {
-                    s.push_str(&format!(" {}", arg.to_sexp()));
-                }
-                s.push(')');
-                s
+            format!("({op} {})", args.iter().map(|x| x.to_sexp()).collect::<Vec<_>>().join(" "))
         }
         match self {
             Expr::F64(x) => format!("{x}"),

--- a/src/bundle.rs
+++ b/src/bundle.rs
@@ -28,6 +28,7 @@ pub fn export(
     bundle: &str,
     use_super_mechs: bool,
     ions: &[String],
+    cat_prefix: &str
 ) -> Result<()> {
     export_template(lems, nml, bundle)?;
 
@@ -37,7 +38,7 @@ pub fn export(
     if use_super_mechs {
         export_with_super_mechanisms(lems, nml, bundle)?;
     } else {
-        acc::export(lems, nml, &format!("{}/acc", bundle))?;
+        acc::export(lems, nml, &format!("{}/acc", bundle), cat_prefix)?;
     }
     Ok(())
 }
@@ -209,6 +210,8 @@ fn mk_main_py(
     }
     gid_to_labels.push_str("                               }");
 
+    let cat_prefix = "local_";
+
     Ok(format!(
         "#!/usr/bin/env python3
 import arbor as A
@@ -237,7 +240,7 @@ class recipe(A.recipe):
         A.recipe.__init__(self)
         self.props = A.neuron_cable_properties()
         cat = compile(here / 'local-catalogue.so', here / 'cat')
-        self.props.catalogue.extend(cat, '')
+        self.props.catalogue.extend(cat, '{cat_prefix}')
         self.cell_to_morph = {}
         self.gid_to_cell = {}
         self.i_clamps = {}

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -36,6 +36,8 @@ pub enum Expr {
     Log(Box<Expr>),
     Sqrt(Box<Expr>),
     H(Box<Expr>),
+    ProximalDistanceFromRegion(String),
+    DistanceFromRoot(),
 }
 
 impl Expr {
@@ -108,6 +110,12 @@ impl Expr {
                 })
                 .collect::<Vec<_>>()
                 .join("^"),
+            Expr::ProximalDistanceFromRegion(_) => {
+                panic!("ProximalDistanceFromRegion can not be constructed in xml")
+            }
+            Expr::DistanceFromRoot() => {
+                panic!("DistanceFromRoot can not be constructed in xml")
+            }
             Expr::H(_) => {
                 panic!("Heaviside step is not supported in nmodl")
             }

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -707,6 +707,20 @@ fn simplify_mul(es: &[Expr]) -> Expr {
         result.push(Expr::F64(lit));
     }
     result.sort_by(|a, b| a.partial_cmp(b).unwrap());
+    let mut i = 0;
+    while result.len() > 0 && i < result.len() - 1 {
+        if let (Expr::Var(a), Expr::Pow(pow_args)) = (
+            &result[i], &result[i+1]) {
+            if let [Expr::Var(b), Expr::F64(pow_num)] = pow_args.as_slice() {
+                if a == b && *pow_num == -1.0 {
+                    result.remove(i);
+                    result.remove(i);
+                }
+            }
+        }
+        i += 1;
+    }
+
     match &result[..] {
         [] => Expr::F64(1.0),
         [x] => x.clone(),
@@ -846,6 +860,7 @@ mod test {
                 Expr::Var(String::from("z")),
             ])
         );
+        assert_eq!(Expr::parse("a / a").unwrap(), Expr::F64(1.0));
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -60,6 +60,10 @@ enum Cmd {
         /// Try to combine channels per segment group
         #[clap(short, long)]
         super_mechanisms: bool,
+        /// Change catalogue prefix.
+        /// Set to empty string if mechanisms do not collide with internal mechanisms
+        #[clap(short, long, default_value="local_")]
+        cat_prefix: String,
         /// Prefix to put bundle
         dir: String,
     },
@@ -111,15 +115,16 @@ fn main() -> Result<()> {
         }
         Cmd::Acc { nml, dir } => {
             get_runtime_types(&mut lems, &nml)?;
-            acc::export(&lems, &nml, &dir)?;
+            acc::export(&lems, &nml, &dir, "")?;
         }
         Cmd::Bundle {
             nml,
             dir,
             super_mechanisms,
+            cat_prefix
         } => {
             get_runtime_types(&mut lems, &[nml.clone()])?;
-            bundle::export(&lems, &[nml], &dir, super_mechanisms, &ions[..])?;
+            bundle::export(&lems, &[nml], &dir, super_mechanisms, &ions[..], &cat_prefix)?;
         }
     }
     Ok(())

--- a/src/nmodl.rs
+++ b/src/nmodl.rs
@@ -358,7 +358,7 @@ fn nmodl_init_block(n: &Nmodl) -> Result<String> {
     let init = n
         .init
         .values()
-        .map(|s| s.print_to_string(2))
+        .map(|s| s.simplify().print_to_string(2))
         .collect::<Vec<String>>()
         .join("\n");
     let mut result = vec![
@@ -418,7 +418,7 @@ fn nmodl_deriv_block(n: &Nmodl) -> Result<String> {
         .variables
         .iter()
         .chain(n.deriv.iter())
-        .map(|(a, b)| (a.clone(), b.clone()))
+        .map(|(a, b)| (a.clone(), b.simplify().clone()))
         .collect::<Map<String, Stmnt>>();
     let mut result = String::from("DERIVATIVE dstate {\n");
     let ls = print_dependency_chains(&roots, &vars, &n.symbols)?;
@@ -456,7 +456,7 @@ fn nmodl_break_block(n: &Nmodl) -> Result<String> {
     let currents = n
         .outputs
         .values()
-        .map(|s| s.print_to_string(2))
+        .map(|s| s.simplify().print_to_string(2))
         .collect::<Vec<String>>()
         .join("\n");
     let deps = print_dependency_chains(&roots, &vars, &n.symbols)?;


### PR DESCRIPTION
This PR contains the changes to nmlcc needed to compile the neuroConstruct NeuroML model for the Layer 5 Pyramidal Cell from [Hay et al.](https://github.com/OpenSourceBrain/L5bPyrCellHayEtAl2011/tree/master/neuroConstruct/generatedNeuroML2)

Is contains the following additions / bugfixes

 - Addition of the Heaviside step function H() in Expr parsing (see also https://github.com/arbor-sim/arbor/pull/1989)
 - Support for inhomogeneous parameters
 - A `X * X^-1 = 1` contraction rule (with test)
 - Another round of simplification after ica variable substitution (to fix surfaceArea * surfaceArea^1)
 - Add the `local_` prefix by default to mechanisms to prevent the `pas` mechanism from colliding with the builtin `pas` mechanism. A command line switch can override this.
 - Add concentrationModels to acc file instead of just generating the mod file

Known issues:

 - Supermechanisms still don't work. Something with ehcn param generation for the moment, but the inhomogeneous parameters are expected to be a problem with supermechanisms as well.

Sorry for the large PR