### PR TITLE
🦹  Export super-mechanisms from `DensityNernst`

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,4 +1,8 @@
-on: [push, pull_request]
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
 
 name: Continuous integration
 
@@ -7,7 +11,7 @@ jobs:
     name: Check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           submodules: recursive
       - uses: actions-rs/toolchain@v1
@@ -24,7 +28,7 @@ jobs:
     name: Test Suite
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           submodules: recursive
       - uses: actions-rs/toolchain@v1
@@ -41,7 +45,7 @@ jobs:
     name: Rustfmt
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           submodules: recursive
       - uses: actions-rs/toolchain@v1
@@ -60,7 +64,7 @@ jobs:
     name: Clippy
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           submodules: recursive
       - uses: actions-rs/toolchain@v1

--- a/src/acc.rs
+++ b/src/acc.rs
@@ -52,7 +52,6 @@ pub fn to_decor(
     Ok(cells)
 }
 
-#[allow(non_snake_case)] // xml..
 pub fn parse_inhomogeneous_parameters(
     cell: &roxmltree::Node<'_, '_>,
 ) -> Result<Map<String, ParsedInhomogeneousParameter>> {
@@ -163,7 +162,7 @@ impl SexpConfig {
         if mech == "nernst" {
             mech.to_string()
         } else {
-            format!("{}{}", self.cat_prefix, mech)
+            format!("{}{mech}", self.cat_prefix)
         }
     }
 }
@@ -298,7 +297,7 @@ impl Sexp for Expr {
                 format!("({} {})", if nm == "H" { "step" } else { nm }, x.to_sexp())
             }
             Expr::ProximalDistanceFromRegion(region) => {
-                format!("(proximal-distance (region \"{}\"))", region)
+                format!("(proximal-distance (region \"{region}\"))")
             }
             Expr::DistanceFromRoot() => "(distance (root))".to_string(),
         }
@@ -498,7 +497,6 @@ pub fn biophys(
     Ok(decor)
 }
 
-#[allow(non_snake_case)] // xml..
 fn membrane(
     membrane: &MembraneProperties,
     known_ions: &[String],
@@ -609,7 +607,7 @@ fn membrane(
             }) => {
                 use crate::neuroml::raw::ChannelDensityNonUniformNernstBody::variableParameter;
                 use crate::neuroml::raw::VariableParameterBody::inhomogeneousValue;
-                let (param, segmentGroup, ihb) = match &body[..] {
+                let (param, group, ihb) = match &body[..] {
                     [variableParameter(VariableParameter {
                         parameter,
                         segmentGroup,
@@ -643,7 +641,7 @@ fn membrane(
                 }
                 result.push(Decor::nernst(ion));
                 result.push(Decor::non_uniform_mechanism(
-                    segmentGroup,
+                    group,
                     ionChannel,
                     &Map::new(),
                     &ns,
@@ -685,17 +683,14 @@ fn intra(intra: &IntracellularProperties) -> Result<Vec<Decor>> {
             }) => {
                 result.push(Decor::xi(segmentGroup, ion, initialConcentration));
                 result.push(Decor::xo(segmentGroup, ion, initialExtConcentration));
-                result.push(Decor::new(
+                result.push(Decor::mechanism(
                     segmentGroup,
-                    Paintable::Mech(
-                        concentrationModel.to_string(),
-                        Map::from([(
-                            String::from("initialConcentration"),
-                            initialConcentration.to_string(),
-                        )]),
-                    ),
-                    false,
-                ));
+                    concentrationModel,
+                    &Map::from([(
+                        String::from("initialConcentration"),
+                        initialConcentration.to_string(),
+                    )]),
+                ))
             }
             resistivity(Resistivity {
                 value,

--- a/src/acc.rs
+++ b/src/acc.rs
@@ -136,7 +136,7 @@ impl Sexp for Paintable {
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
 pub enum Decor {
     Default(Paintable),
-    Paint(String, Paintable),
+    Paint(String, Paintable), // region -> what
 }
 
 impl Decor {

--- a/src/acc.rs
+++ b/src/acc.rs
@@ -161,42 +161,6 @@ pub struct MechVariableParameter {
     value: String, // 10 * p
 }
 
-impl MechVariableParameter {
-    pub fn to_inhomogeneous(&self, inhomogeneous_parameters: &Map<String, ParsedInhomogeneousParameter>,
-) -> Result<Map<String, MechVariableParameter>> {
-    use crate::neuroml::raw::VariableParameterBody::inhomogeneousValue;
-    if vp.body.len() != 1 {
-        return Err(acc_unimplemented(
-            "InhomogeneousValue must contain a single InhomogeneousParameter",
-        ));
-    }
-    let inhomogeneousValue(ival) = &vp.body[0];
-    let ihv = inhomogeneous_parameters
-        .get(&ival.inhomogeneousParameter)
-        .ok_or(nml2_error!(
-            "Inhomogeneous parameter definition {} not found",
-            ival.inhomogeneousParameter
-        ))?;
-
-    let parameter = rename_cond_density_to_conductance(&vp.parameter);
-
-    let expr = Expr::parse(&ival.value)?
-        .map(&|ex| -> _ {
-            if ex.is_var_with_name(&ihv.variable) {
-                ihv.metric.clone()
-            } else {
-                ex.clone()
-            }
-        })
-        .to_sexp();
-
-    let instance = MechVariableParameter { value: expr };
-
-    let ns = Map::from([(parameter, instance)]);
-    Ok(ns)
-    }
-}
-
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd)]
 pub enum Paintable {
     Xi(String, String),

--- a/src/acc.rs
+++ b/src/acc.rs
@@ -156,7 +156,7 @@ pub struct ParsedInhomogeneousParameter {
     metric: Expr,
 }
 
-#[derive(Clone, Debug, PartialEq, PartialOrd)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd)]
 pub struct MechVariableParameter {
     value: String, // 10 * p
 }

--- a/src/acc.rs
+++ b/src/acc.rs
@@ -161,7 +161,7 @@ pub struct MechVariableParameter {
     value: String, // 10 * p
 }
 
-#[derive(Clone, Debug, PartialEq, PartialOrd)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd)]
 pub enum Paintable {
     Xi(String, String),
     Xo(String, String),

--- a/src/acc.rs
+++ b/src/acc.rs
@@ -288,7 +288,7 @@ impl Sexp for Paintable {
     }
 }
 
-#[derive(Clone, Debug, PartialEq, PartialOrd)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd)]
 pub enum Decor {
     Default(Paintable),
     Paint(String, Paintable), // region -> what

--- a/src/bundle.rs
+++ b/src/bundle.rs
@@ -1,5 +1,5 @@
 use crate::{
-    acc::{self, Decor, Paintable, ParsedInhomogeneousParameter, Sexp, SexpConfig},
+    acc::{self, Decor, Paintable, ParsedInhomogeneousParameter, Sexp},
     error::{Error, Result},
     expr::{Expr, Quantity, Stmnt},
     instance::{Collapsed, Context, Instance},
@@ -432,12 +432,12 @@ pub fn export_with_super_mechanisms(
         }
         let path = format!("{bundle}/acc/{id}.acc");
         info!("Writing Super Mechanism ACC to {path:?}");
-        write(
-            &path,
-            cell.decor.to_sexp_with_config(&SexpConfig {
-                cat_prefix: cat_prefix.into(),
-            }),
-        )?;
+        let decor = cell
+            .decor
+            .iter()
+            .map(|d| d.add_catalogue_prefix(cat_prefix))
+            .collect::<Vec<_>>();
+        write(&path, decor.to_sexp())?;
     }
     Ok(())
 }

--- a/src/lems/file.rs
+++ b/src/lems/file.rs
@@ -114,6 +114,7 @@ impl LemsFile {
             ("K", "temperature"),
             ("J_per_K_per_mol", "idealGasConstantDims"),
             ("nS_per_mV", "conductance_per_voltage"),
+            ("mol_per_cm_per_uA_per_ms", "rho_factor") // NOTE(TH) this is questionable
         ];
 
         let dimensions = raw

--- a/src/lems/file.rs
+++ b/src/lems/file.rs
@@ -114,7 +114,7 @@ impl LemsFile {
             ("K", "temperature"),
             ("J_per_K_per_mol", "idealGasConstantDims"),
             ("nS_per_mV", "conductance_per_voltage"),
-            ("mol_per_cm_per_uA_per_ms", "rho_factor") // NOTE(TH) this is questionable
+            ("mol_per_cm_per_uA_per_ms", "rho_factor"), // NOTE(TH) this is questionable
         ];
 
         let dimensions = raw


### PR DESCRIPTION
Add export for ion channels added via `ChannelDensityNernst`

@llandsmeer could you add similar functionality for the `NonUniform*` 
variants? It should mesh with the current setup, you just need to add
the non-uniform parameters to the non-flatten list.