### PR TITLE
Remove redundant if-statements

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ tracing            = { version = "^0.1" }
 tracing-subscriber = { version = "^0.2" }
 anyhow             = { version = "^1.0.0", features = ["backtrace"] }
 thiserror          = { version = "^1.0.0" }
+pretty_assertions  = { version = "^1.3.0" }
 
 [[bin]]
 name = "nmlcc"

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -330,7 +330,6 @@ impl Boolean {
 
     pub fn parse(input: &str) -> Result<Self> {
         if let Ok((_, result)) = parse::boolean(input) {
-            eprintln!("{:?}", result);
             Ok(result.simplify())
         } else {
             Err(parse_error!("Could not parse {}", input))
@@ -374,7 +373,8 @@ impl Boolean {
                 match o {
                     Op::And => match (&l, &r) {
                         // eliminate literals
-                        (Boolean::Lit(true), Boolean::Lit(true)) => return Boolean::Lit(true),
+                        (Boolean::Lit(true), r) => return r.clone(),
+                        (l, Boolean::Lit(true)) => return l.clone(),
                         (Boolean::Lit(false), _) |
                         (_, Boolean::Lit(false)) => return Boolean::Lit(false),
                         // peek one level into comparisons
@@ -428,8 +428,9 @@ impl Boolean {
                     }
                     Op::Or => match (&l, &r) {
                         // eliminate literals
-                        (Boolean::Lit(false), Boolean::Lit(false)) => return Boolean::Lit(false),
-                        (Boolean::Lit(true), _) => return Boolean::Lit(true),
+                        (Boolean::Lit(false), r) => return r.clone(),
+                        (l, Boolean::Lit(false)) => return l.clone(),
+                        (Boolean::Lit(true), _) |
                         (_, Boolean::Lit(true)) => return Boolean::Lit(true),
                         // peek one level into comparisons
                         (Boolean::Cmp(el, xl, yl), Boolean::Cmp(er, xr, yr))

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -375,103 +375,143 @@ impl Boolean {
                         // eliminate literals
                         (Boolean::Lit(true), r) => return r.clone(),
                         (l, Boolean::Lit(true)) => return l.clone(),
-                        (Boolean::Lit(false), _) |
-                        (_, Boolean::Lit(false)) => return Boolean::Lit(false),
+                        (Boolean::Lit(false), _) | (_, Boolean::Lit(false)) => {
+                            return Boolean::Lit(false)
+                        }
                         // peek one level into comparisons
                         (Boolean::Cmp(el, xl, yl), Boolean::Cmp(er, xr, yr))
-                            if xl == xr && yl == yr => {
-                                match (&el, &er) {
-                                    // ...
-                                    (u, v) if u == v =>  return Boolean::Cmp(**u, xl.clone(), yl.clone()),
-                                    // contradiction
-                                    (Cmp::Ne, Cmp::Eq) |
-                                    (Cmp::Eq, Cmp::Ne) |
-                                    (Cmp::Gt, Cmp::Lt) |
-                                    (Cmp::Lt, Cmp::Gt) |
-                                    (Cmp::Ge, Cmp::Lt) |
-                                    (Cmp::Lt, Cmp::Ge) |
-                                    (Cmp::Gt, Cmp::Le) |
-                                    (Cmp::Le, Cmp::Gt) => return Boolean::Lit(false),
-                                    // redundant
-                                    (Cmp::Le, Cmp::Eq) |
-                                    (Cmp::Eq, Cmp::Le) |
-                                    (Cmp::Le, Cmp::Lt) |
-                                    (Cmp::Lt, Cmp::Le) => return Boolean::Cmp(Cmp::Le, xl.clone(), yl.clone()),
-                                    (Cmp::Ge, Cmp::Eq) |
-                                    (Cmp::Eq, Cmp::Ge) |
-                                    (Cmp::Ge, Cmp::Gt) |
-                                    (Cmp::Gt, Cmp::Ge) => return Boolean::Cmp(Cmp::Ge, xl.clone(), yl.clone()),
-                                    // intersection
-                                    (Cmp::Ge, Cmp::Le) |
-                                    (Cmp::Le, Cmp::Ge) => return Boolean::Cmp(Cmp::Eq, xl.clone(), yl.clone()),
-                                    _ => unreachable!(),
+                            if xl == xr && yl == yr =>
+                        {
+                            match (&el, &er) {
+                                // ...
+                                (u, v) if u == v => {
+                                    return Boolean::Cmp(**u, xl.clone(), yl.clone())
                                 }
+                                // contradiction
+                                (Cmp::Ne, Cmp::Eq)
+                                | (Cmp::Eq, Cmp::Ne)
+                                | (Cmp::Lt, Cmp::Eq)
+                                | (Cmp::Eq, Cmp::Lt)
+                                | (Cmp::Gt, Cmp::Eq)
+                                | (Cmp::Eq, Cmp::Gt)
+                                | (Cmp::Gt, Cmp::Lt)
+                                | (Cmp::Lt, Cmp::Gt)
+                                | (Cmp::Ge, Cmp::Lt)
+                                | (Cmp::Lt, Cmp::Ge)
+                                | (Cmp::Gt, Cmp::Le)
+                                | (Cmp::Le, Cmp::Gt) => return Boolean::Lit(false),
+                                // redundant
+                                (Cmp::Le, Cmp::Eq)
+                                | (Cmp::Eq, Cmp::Le)
+                                | (Cmp::Le, Cmp::Lt)
+                                | (Cmp::Lt, Cmp::Le) => {
+                                    return Boolean::Cmp(Cmp::Le, xl.clone(), yl.clone())
+                                }
+                                (Cmp::Ge, Cmp::Eq)
+                                | (Cmp::Eq, Cmp::Ge)
+                                | (Cmp::Ge, Cmp::Gt)
+                                | (Cmp::Gt, Cmp::Ge) => {
+                                    return Boolean::Cmp(Cmp::Ge, xl.clone(), yl.clone())
+                                }
+                                (Cmp::Ne, Cmp::Gt) | (Cmp::Gt, Cmp::Ne) => {
+                                    return Boolean::Cmp(Cmp::Gt, xl.clone(), yl.clone())
+                                }
+                                (Cmp::Ne, Cmp::Lt) | (Cmp::Lt, Cmp::Ne) => {
+                                    return Boolean::Cmp(Cmp::Gt, xl.clone(), yl.clone())
+                                }
+                                // intersection
+                                (Cmp::Ge, Cmp::Le) | (Cmp::Le, Cmp::Ge) => {
+                                    return Boolean::Cmp(Cmp::Eq, xl.clone(), yl.clone())
+                                }
+                                _ => unreachable!(),
                             }
-                        (l@Boolean::Cmp(_, xl, yl), Boolean::Cmp(er, xr, yr))
-                            if xl == yr && yl == xr => {
-                                // want to swap the second comparison
-                                let er = match er {
-                                    Cmp::Eq => Cmp::Eq,
-                                    Cmp::Ne => Cmp::Ne,
-                                    Cmp::Ge => Cmp::Le,
-                                    Cmp::Le => Cmp::Ge,
-                                    Cmp::Gt => Cmp::Lt,
-                                    Cmp::Lt => Cmp::Gt,
-                                };
-                                return Boolean::Op(Op::And,
-                                                   Box::new(l.clone()),
-                                                   Box::new(Boolean::Cmp(er,
-                                                                         yr.clone(),
-                                                                         xr.clone())))
-                            }
+                        }
+                        (l @ Boolean::Cmp(_, xl, yl), Boolean::Cmp(er, xr, yr))
+                            if xl == yr && yl == xr =>
+                        {
+                            // want to swap the second comparison
+                            let er = match er {
+                                Cmp::Eq => Cmp::Eq,
+                                Cmp::Ne => Cmp::Ne,
+                                Cmp::Ge => Cmp::Le,
+                                Cmp::Le => Cmp::Ge,
+                                Cmp::Gt => Cmp::Lt,
+                                Cmp::Lt => Cmp::Gt,
+                            };
+                            return Boolean::Op(
+                                Op::And,
+                                Box::new(l.clone()),
+                                Box::new(Boolean::Cmp(er, yr.clone(), xr.clone())),
+                            );
+                        }
                         _ => {}
-                    }
+                    },
                     Op::Or => match (&l, &r) {
                         // eliminate literals
                         (Boolean::Lit(false), r) => return r.clone(),
                         (l, Boolean::Lit(false)) => return l.clone(),
-                        (Boolean::Lit(true), _) |
-                        (_, Boolean::Lit(true)) => return Boolean::Lit(true),
+                        (Boolean::Lit(true), _) | (_, Boolean::Lit(true)) => {
+                            return Boolean::Lit(true)
+                        }
                         // peek one level into comparisons
                         (Boolean::Cmp(el, xl, yl), Boolean::Cmp(er, xr, yr))
-                            if xl == xr && yl == yr => {
-                                match (&el, &er) {
-                                    // ...
-                                    (u, v) if u == v =>  return Boolean::Cmp(**u, xl.clone(), xr.clone()),
-                                    // x > y || x < y => x /= y
-                                    (Cmp::Lt, Cmp::Gt) | (Cmp::Gt, Cmp::Lt) => return Boolean::Cmp(Cmp::Ne, xl.clone(), yl.clone()),
-                                    // tautology
-                                    (Cmp::Ne, Cmp::Eq) | (Cmp::Eq, Cmp::Ne) |
-                                    (Cmp::Ge, Cmp::Le) | (Cmp::Le, Cmp::Ge) |
-                                    (Cmp::Gt, Cmp::Le) | (Cmp::Le, Cmp::Gt) |
-                                    (Cmp::Ge, Cmp::Lt) | (Cmp::Lt, Cmp::Ge) => return Boolean::Lit(true),
-                                    // redundant
-                                    (Cmp::Ge, Cmp::Eq) |
-                                    (Cmp::Eq, Cmp::Ge) => return Boolean::Cmp(Cmp::Ge, xl.clone(), yl.clone()),
-                                    (Cmp::Le, Cmp::Eq) |
-                                    (Cmp::Eq, Cmp::Le) => return Boolean::Cmp(Cmp::Le, xl.clone(), yl.clone()),
-                                    _ => unreachable!(),
+                            if xl == xr && yl == yr =>
+                        {
+                            match (&el, &er) {
+                                // ...
+                                (u, v) if u == v => {
+                                    return Boolean::Cmp(**u, xl.clone(), xr.clone())
                                 }
+                                // x > y || x < y => x /= y
+                                (Cmp::Lt, Cmp::Gt) | (Cmp::Gt, Cmp::Lt) => {
+                                    return Boolean::Cmp(Cmp::Ne, xl.clone(), yl.clone())
+                                }
+                                // tautology
+                                (Cmp::Ne, Cmp::Eq)
+                                | (Cmp::Eq, Cmp::Ne)
+                                | (Cmp::Ge, Cmp::Le)
+                                | (Cmp::Le, Cmp::Ge)
+                                | (Cmp::Gt, Cmp::Le)
+                                | (Cmp::Le, Cmp::Gt)
+                                | (Cmp::Ge, Cmp::Lt)
+                                | (Cmp::Lt, Cmp::Ge) => return Boolean::Lit(true),
+                                // redundant
+                                (Cmp::Ge, Cmp::Eq) | (Cmp::Eq, Cmp::Ge) => {
+                                    return Boolean::Cmp(Cmp::Ge, xl.clone(), yl.clone())
+                                }
+                                (Cmp::Le, Cmp::Eq) | (Cmp::Eq, Cmp::Le) => {
+                                    return Boolean::Cmp(Cmp::Le, xl.clone(), yl.clone())
+                                }
+                                // return the weaker condition
+                                (Cmp::Gt, Cmp::Ne)
+                                | (Cmp::Ne, Cmp::Gt)
+                                | (Cmp::Lt, Cmp::Ne)
+                                | (Cmp::Ne, Cmp::Lt) => {
+                                    return Boolean::Cmp(Cmp::Ne, xl.clone(), yl.clone())
+                                }
+                                _ => unreachable!(),
                             }
-                        (l@Boolean::Cmp(_, xl, yl), Boolean::Cmp(er, xr, yr))
-                            if xl == yr && yl == xr => {
-                                // want to swap the second comparison
-                                let er = match er {
-                                    Cmp::Eq => Cmp::Eq,
-                                    Cmp::Ne => Cmp::Ne,
-                                    Cmp::Ge => Cmp::Le,
-                                    Cmp::Le => Cmp::Ge,
-                                    Cmp::Gt => Cmp::Lt,
-                                    Cmp::Lt => Cmp::Gt,
-                                };
-                                return Boolean::Op(Op::Or,
-                                                   Box::new(l.clone()),
-                                                   Box::new(Boolean::Cmp(er,
-                                                                         yr.clone(),
-                                                                         xr.clone())))
-                            }
+                        }
+                        (l @ Boolean::Cmp(_, xl, yl), Boolean::Cmp(er, xr, yr))
+                            if xl == yr && yl == xr =>
+                        {
+                            // want to swap the second comparison
+                            let er = match er {
+                                Cmp::Eq => Cmp::Eq,
+                                Cmp::Ne => Cmp::Ne,
+                                Cmp::Ge => Cmp::Le,
+                                Cmp::Le => Cmp::Ge,
+                                Cmp::Gt => Cmp::Lt,
+                                Cmp::Lt => Cmp::Gt,
+                            };
+                            return Boolean::Op(
+                                Op::Or,
+                                Box::new(l.clone()),
+                                Box::new(Boolean::Cmp(er, yr.clone(), xr.clone())),
+                            );
+                        }
                         _ => {}
-                    }
+                    },
                 }
                 Boolean::Op(*o, Box::new(l), Box::new(r))
             }
@@ -1154,18 +1194,29 @@ mod test {
         assert_eq!(Boolean::parse("23 .gt. 42").unwrap(), Boolean::Lit(false));
         assert_eq!(Boolean::parse("23 .lt. 42").unwrap(), Boolean::Lit(true));
         assert_eq!(Boolean::parse("x .eq. x").unwrap(), Boolean::Lit(true));
-        assert_eq!(Boolean::parse("(x .gt. y) .and. (x .lt. z)").unwrap(),
-                   Boolean::Op(Op::And,
-                               Box::new(Boolean::parse("x .gt. y").unwrap()),
-                               Box::new(Boolean::parse("x .lt. z").unwrap())));
-        assert_eq!(Boolean::parse("(x .gt. y) .and. (x .lt. y)").unwrap(),
-                   Boolean::Lit(false));
-        assert_eq!(Boolean::parse("(x .gt. y) .or. (x .lt. y)").unwrap(),
-                   Boolean::parse("x .neq. y").unwrap());
-        assert_eq!(Boolean::parse("(x .neq. y) .or. (x .eq. y)").unwrap(),
-                   Boolean::Lit(true));
-        assert_eq!(Boolean::parse("(x .neq. y) .and. (x .eq. y)").unwrap(),
-                   Boolean::Lit(false));
+        assert_eq!(
+            Boolean::parse("(x .gt. y) .and. (x .lt. z)").unwrap(),
+            Boolean::Op(
+                Op::And,
+                Box::new(Boolean::parse("x .gt. y").unwrap()),
+                Box::new(Boolean::parse("x .lt. z").unwrap())
+            )
+        );
+        assert_eq!(
+            Boolean::parse("(x .gt. y) .and. (x .lt. y)").unwrap(),
+            Boolean::Lit(false)
+        );
+        assert_eq!(
+            Boolean::parse("(x .gt. y) .or. (x .lt. y)").unwrap(),
+            Boolean::parse("x .neq. y").unwrap()
+        );
+        assert_eq!(
+            Boolean::parse("(x .neq. y) .or. (x .eq. y)").unwrap(),
+            Boolean::Lit(true)
+        );
+        assert_eq!(
+            Boolean::parse("(x .neq. y) .and. (x .eq. y)").unwrap(),
+            Boolean::Lit(false)
+        );
     }
-
 }

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -330,6 +330,7 @@ impl Boolean {
 
     pub fn parse(input: &str) -> Result<Self> {
         if let Ok((_, result)) = parse::boolean(input) {
+            eprintln!("{:?}", result);
             Ok(result.simplify())
         } else {
             Err(parse_error!("Could not parse {}", input))
@@ -341,34 +342,137 @@ impl Boolean {
             Boolean::Cmp(o, l, r) => {
                 let l = l.simplify();
                 let r = r.simplify();
-                match (&l, &r) {
-                    (Expr::F64(x), Expr::F64(y)) => {
-                        let r = match o {
-                            Cmp::Eq => x == y,
-                            Cmp::Ne => x != y,
-                            Cmp::Ge => x >= y,
-                            Cmp::Le => x <= y,
-                            Cmp::Gt => x > y,
-                            Cmp::Lt => x < y,
-                        };
-                        Boolean::Lit(r)
+                if l == r {
+                    match o {
+                        Cmp::Ge | Cmp::Le | Cmp::Eq => Boolean::Lit(true),
+                        Cmp::Gt | Cmp::Lt | Cmp::Ne => Boolean::Lit(false),
                     }
-                    _ => Boolean::Cmp(*o, Box::new(l), Box::new(r)),
+                } else {
+                    match (&l, &r) {
+                        (Expr::F64(x), Expr::F64(y)) => {
+                            let r = match o {
+                                Cmp::Eq => x == y,
+                                Cmp::Ne => x != y,
+                                Cmp::Lt => x < y,
+                                Cmp::Le => x <= y,
+                                Cmp::Gt => x > y,
+                                Cmp::Ge => x >= y,
+                            };
+                            Boolean::Lit(r)
+                        }
+                        _ => Boolean::Cmp(*o, Box::new(l), Box::new(r)),
+                    }
                 }
             }
             Boolean::Op(o, l, r) => {
                 let l = l.simplify();
                 let r = r.simplify();
-                match (&l, &r) {
-                    (Boolean::Lit(x), Boolean::Lit(y)) => {
-                        let r = match o {
-                            Op::And => *x && *y,
-                            Op::Or => *x || *y,
-                        };
-                        Boolean::Lit(r)
-                    }
-                    _ => Boolean::Op(*o, Box::new(l), Box::new(r)),
+                // x && x == x || x
+                if l == r {
+                    return l;
                 }
+                match o {
+                    Op::And => match (&l, &r) {
+                        // eliminate literals
+                        (Boolean::Lit(true), Boolean::Lit(true)) => return Boolean::Lit(true),
+                        (Boolean::Lit(false), _) |
+                        (_, Boolean::Lit(false)) => return Boolean::Lit(false),
+                        // peek one level into comparisons
+                        (Boolean::Cmp(el, xl, yl), Boolean::Cmp(er, xr, yr))
+                            if xl == xr && yl == yr => {
+                                match (&el, &er) {
+                                    // ...
+                                    (u, v) if u == v =>  return Boolean::Cmp(**u, xl.clone(), yl.clone()),
+                                    // contradiction
+                                    (Cmp::Ne, Cmp::Eq) |
+                                    (Cmp::Eq, Cmp::Ne) |
+                                    (Cmp::Gt, Cmp::Lt) |
+                                    (Cmp::Lt, Cmp::Gt) |
+                                    (Cmp::Ge, Cmp::Lt) |
+                                    (Cmp::Lt, Cmp::Ge) |
+                                    (Cmp::Gt, Cmp::Le) |
+                                    (Cmp::Le, Cmp::Gt) => return Boolean::Lit(false),
+                                    // redundant
+                                    (Cmp::Le, Cmp::Eq) |
+                                    (Cmp::Eq, Cmp::Le) |
+                                    (Cmp::Le, Cmp::Lt) |
+                                    (Cmp::Lt, Cmp::Le) => return Boolean::Cmp(Cmp::Le, xl.clone(), yl.clone()),
+                                    (Cmp::Ge, Cmp::Eq) |
+                                    (Cmp::Eq, Cmp::Ge) |
+                                    (Cmp::Ge, Cmp::Gt) |
+                                    (Cmp::Gt, Cmp::Ge) => return Boolean::Cmp(Cmp::Ge, xl.clone(), yl.clone()),
+                                    // intersection
+                                    (Cmp::Ge, Cmp::Le) |
+                                    (Cmp::Le, Cmp::Ge) => return Boolean::Cmp(Cmp::Eq, xl.clone(), yl.clone()),
+                                    _ => unreachable!(),
+                                }
+                            }
+                        (l@Boolean::Cmp(_, xl, yl), Boolean::Cmp(er, xr, yr))
+                            if xl == yr && yl == xr => {
+                                // want to swap the second comparison
+                                let er = match er {
+                                    Cmp::Eq => Cmp::Eq,
+                                    Cmp::Ne => Cmp::Ne,
+                                    Cmp::Ge => Cmp::Le,
+                                    Cmp::Le => Cmp::Ge,
+                                    Cmp::Gt => Cmp::Lt,
+                                    Cmp::Lt => Cmp::Gt,
+                                };
+                                return Boolean::Op(Op::And,
+                                                   Box::new(l.clone()),
+                                                   Box::new(Boolean::Cmp(er,
+                                                                         yr.clone(),
+                                                                         xr.clone())))
+                            }
+                        _ => {}
+                    }
+                    Op::Or => match (&l, &r) {
+                        // eliminate literals
+                        (Boolean::Lit(false), Boolean::Lit(false)) => return Boolean::Lit(false),
+                        (Boolean::Lit(true), _) => return Boolean::Lit(true),
+                        (_, Boolean::Lit(true)) => return Boolean::Lit(true),
+                        // peek one level into comparisons
+                        (Boolean::Cmp(el, xl, yl), Boolean::Cmp(er, xr, yr))
+                            if xl == xr && yl == yr => {
+                                match (&el, &er) {
+                                    // ...
+                                    (u, v) if u == v =>  return Boolean::Cmp(**u, xl.clone(), xr.clone()),
+                                    // x > y || x < y => x /= y
+                                    (Cmp::Lt, Cmp::Gt) | (Cmp::Gt, Cmp::Lt) => return Boolean::Cmp(Cmp::Ne, xl.clone(), yl.clone()),
+                                    // tautology
+                                    (Cmp::Ne, Cmp::Eq) | (Cmp::Eq, Cmp::Ne) |
+                                    (Cmp::Ge, Cmp::Le) | (Cmp::Le, Cmp::Ge) |
+                                    (Cmp::Gt, Cmp::Le) | (Cmp::Le, Cmp::Gt) |
+                                    (Cmp::Ge, Cmp::Lt) | (Cmp::Lt, Cmp::Ge) => return Boolean::Lit(true),
+                                    // redundant
+                                    (Cmp::Ge, Cmp::Eq) |
+                                    (Cmp::Eq, Cmp::Ge) => return Boolean::Cmp(Cmp::Ge, xl.clone(), yl.clone()),
+                                    (Cmp::Le, Cmp::Eq) |
+                                    (Cmp::Eq, Cmp::Le) => return Boolean::Cmp(Cmp::Le, xl.clone(), yl.clone()),
+                                    _ => unreachable!(),
+                                }
+                            }
+                        (l@Boolean::Cmp(_, xl, yl), Boolean::Cmp(er, xr, yr))
+                            if xl == yr && yl == xr => {
+                                // want to swap the second comparison
+                                let er = match er {
+                                    Cmp::Eq => Cmp::Eq,
+                                    Cmp::Ne => Cmp::Ne,
+                                    Cmp::Ge => Cmp::Le,
+                                    Cmp::Le => Cmp::Ge,
+                                    Cmp::Gt => Cmp::Lt,
+                                    Cmp::Lt => Cmp::Gt,
+                                };
+                                return Boolean::Op(Op::Or,
+                                                   Box::new(l.clone()),
+                                                   Box::new(Boolean::Cmp(er,
+                                                                         yr.clone(),
+                                                                         xr.clone())))
+                            }
+                        _ => {}
+                    }
+                }
+                Boolean::Op(*o, Box::new(l), Box::new(r))
             }
             _ => self.clone(),
         }
@@ -685,7 +789,7 @@ mod parse {
     }
 
     pub fn boolean(input: &str) -> IResult<&str, Boolean> {
-        alt((cmp, op))(input)
+        alt((op, cmp))(input)
     }
 }
 
@@ -906,6 +1010,7 @@ fn simplify_sqrt(es: &Expr) -> Expr {
 #[cfg(test)]
 mod test {
     use super::*;
+    use pretty_assertions::assert_eq;
 
     #[test]
     fn test_parse() {
@@ -1042,4 +1147,24 @@ mod test {
             vec![String::from("a_b/c/foo"), String::from("a_b/c/foo_bar"),]
         );
     }
+
+    #[test]
+    fn test_bool() {
+        assert_eq!(Boolean::parse("23 .gt. 42").unwrap(), Boolean::Lit(false));
+        assert_eq!(Boolean::parse("23 .lt. 42").unwrap(), Boolean::Lit(true));
+        assert_eq!(Boolean::parse("x .eq. x").unwrap(), Boolean::Lit(true));
+        assert_eq!(Boolean::parse("(x .gt. y) .and. (x .lt. z)").unwrap(),
+                   Boolean::Op(Op::And,
+                               Box::new(Boolean::parse("x .gt. y").unwrap()),
+                               Box::new(Boolean::parse("x .lt. z").unwrap())));
+        assert_eq!(Boolean::parse("(x .gt. y) .and. (x .lt. y)").unwrap(),
+                   Boolean::Lit(false));
+        assert_eq!(Boolean::parse("(x .gt. y) .or. (x .lt. y)").unwrap(),
+                   Boolean::parse("x .neq. y").unwrap());
+        assert_eq!(Boolean::parse("(x .neq. y) .or. (x .eq. y)").unwrap(),
+                   Boolean::Lit(true));
+        assert_eq!(Boolean::parse("(x .neq. y) .and. (x .eq. y)").unwrap(),
+                   Boolean::Lit(false));
+    }
+
 }

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -429,7 +429,7 @@ impl Boolean {
                         (l @ Boolean::Cmp(_, xl, yl), Boolean::Cmp(er, xr, yr))
                             if xl == yr && yl == xr =>
                         {
-                            // want to swap the second comparison
+                            // to swap the second comparison invert the operator
                             let er = match er {
                                 Cmp::Eq => Cmp::Eq,
                                 Cmp::Ne => Cmp::Ne,
@@ -495,7 +495,7 @@ impl Boolean {
                         (l @ Boolean::Cmp(_, xl, yl), Boolean::Cmp(er, xr, yr))
                             if xl == yr && yl == xr =>
                         {
-                            // want to swap the second comparison
+                            // to swap the second comparison invert the operator
                             let er = match er {
                                 Cmp::Eq => Cmp::Eq,
                                 Cmp::Ne => Cmp::Ne,

--- a/src/nmodl.rs
+++ b/src/nmodl.rs
@@ -139,8 +139,14 @@ impl Nmodl {
                 let mut init = false;
                 for c in cs {
                     ms.push(c.clone());
-                    eprintln!("{}| {nm} = {}", c.0.print_to_string(), c.1.print_to_string());
-                    covers = expr::Boolean::Op(expr::Op::Or, Box::new(c.0.clone()), Box::new(covers)).simplify();
+                    eprintln!(
+                        "{}| {nm} = {}",
+                        c.0.print_to_string(),
+                        c.1.print_to_string()
+                    );
+                    covers =
+                        expr::Boolean::Op(expr::Op::Or, Box::new(c.0.clone()), Box::new(covers))
+                            .simplify();
                     if let expr::Boolean::Lit(true) = covers {
                         eprintln!("COVERING! Stopp!");
                         init = true;
@@ -164,9 +170,7 @@ impl Nmodl {
                 let mut res = Stmnt::Ass(nm.clone(), e);
 
                 while let Some((c, e)) = ms.pop() {
-                    res = Stmnt::Ift(c,
-                                     Box::new(Stmnt::Ass(nm.clone(), e)),
-                                     Box::new(Some(res)));
+                    res = Stmnt::Ift(c, Box::new(Stmnt::Ass(nm.clone(), e)), Box::new(Some(res)));
                 }
                 variables.insert(nm, res.simplify());
             }

--- a/tests/test_nmodl.rs
+++ b/tests/test_nmodl.rs
@@ -498,30 +498,30 @@ BREAKPOINT {
 
 // #[test]
 // fn non_specific_ion_channel() {
-    // let lems = LemsFile::core();
-    // let tree = Document::parse(r#"<?xml version="1.0" encoding="UTF-8"?>
+// let lems = LemsFile::core();
+// let tree = Document::parse(r#"<?xml version="1.0" encoding="UTF-8"?>
 // <neuroml xmlns="http://www.neuroml.org/schema/neuroml2"
-         // xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         // xsi:schemaLocation="http://www.neuroml.org/schema/neuroml2  ../Schemas/NeuroML2/NeuroML_v2beta4.xsd"
-         // id="NML2_SimpleIonChannel">
-    // <ionChannelHH id="NaConductance" conductance="10pS" species="na">
-        // <gateHHrates id="m" instances="1">
-            // <forwardRate type="HHExpLinearRate" rate="1per_ms" midpoint="-40mV" scale="10mV"/>
-            // <reverseRate type="HHExpRate" rate="4per_ms" midpoint="-65mV" scale="-18mV"/>
-        // </gateHHrates>
-    // </ionChannelHH>
+// xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+// xsi:schemaLocation="http://www.neuroml.org/schema/neuroml2  ../Schemas/NeuroML2/NeuroML_v2beta4.xsd"
+// id="NML2_SimpleIonChannel">
+// <ionChannelHH id="NaConductance" conductance="10pS" species="na">
+// <gateHHrates id="m" instances="1">
+// <forwardRate type="HHExpLinearRate" rate="1per_ms" midpoint="-40mV" scale="10mV"/>
+// <reverseRate type="HHExpRate" rate="4per_ms" midpoint="-65mV" scale="-18mV"/>
+// </gateHHrates>
+// </ionChannelHH>
 
-    // <ionChannelHH id="NaConductance" conductance="10pS" species="k">
-        // <gateHHrates id="m" instances="1">
-            // <forwardRate type="HHExpLinearRate" rate="1per_ms" midpoint="-40mV" scale="10mV"/>
-            // <reverseRate type="HHExpRate" rate="4per_ms" midpoint="-65mV" scale="-18mV"/>
-        // </gateHHrates>
-    // </ionChannelHH>
+// <ionChannelHH id="NaConductance" conductance="10pS" species="k">
+// <gateHHrates id="m" instances="1">
+// <forwardRate type="HHExpLinearRate" rate="1per_ms" midpoint="-40mV" scale="10mV"/>
+// <reverseRate type="HHExpRate" rate="4per_ms" midpoint="-65mV" scale="-18mV"/>
+// </gateHHrates>
+// </ionChannelHH>
 // </neuroml>"#).unwrap();
-    // let node = tree
-        // .descendants()
-        // .find(|n| n.has_tag_name("ionChannelHH"))
-        // .unwrap();
-    // let inst = Instance::new(&lems, &node).unwrap();
-    // assert_eq!(to_nmodl(&inst, "-*", "baseIonChannel", &[]).unwrap(), r#""#);
+// let node = tree
+// .descendants()
+// .find(|n| n.has_tag_name("ionChannelHH"))
+// .unwrap();
+// let inst = Instance::new(&lems, &node).unwrap();
+// assert_eq!(to_nmodl(&inst, "-*", "baseIonChannel", &[]).unwrap(), r#""#);
 // }

--- a/tests/test_nmodl.rs
+++ b/tests/test_nmodl.rs
@@ -2,6 +2,8 @@ use nml2::{instance::Instance, lems::file::LemsFile, nmodl::to_nmodl};
 
 use roxmltree::Document;
 
+use pretty_assertions::assert_eq;
+
 fn ions() -> Vec<String> {
     vec![String::from("na"), String::from("ca"), String::from("k")]
 }
@@ -211,11 +213,7 @@ INITIAL {
   if (gates_m_forwardRate_x != 0) {
     gates_m_forwardRate_r = gates_m_forwardRate_rate * gates_m_forwardRate_x * (1 + -1 * exp(-1 * gates_m_forwardRate_x))^-1
   } else {
-    if (gates_m_forwardRate_x == 0) {
-      gates_m_forwardRate_r = gates_m_forwardRate_rate
-    } else {
-      gates_m_forwardRate_r = 0
-    }
+    gates_m_forwardRate_r = gates_m_forwardRate_rate
   }
   gates_m_inf = gates_m_forwardRate_r * (gates_m_forwardRate_r + gates_m_reverseRate_r)^-1
   gates_h_forwardRate_r = gates_h_forwardRate_rate * exp((v + -1 * gates_h_forwardRate_midpoint) * gates_h_forwardRate_scale^-1)
@@ -233,11 +231,7 @@ DERIVATIVE dstate {
   if (gates_m_forwardRate_x != 0) {
     gates_m_forwardRate_r = gates_m_forwardRate_rate * gates_m_forwardRate_x * (1 + -1 * exp(-1 * gates_m_forwardRate_x))^-1
   } else {
-    if (gates_m_forwardRate_x == 0) {
-      gates_m_forwardRate_r = gates_m_forwardRate_rate
-    } else {
-      gates_m_forwardRate_r = 0
-    }
+    gates_m_forwardRate_r = gates_m_forwardRate_rate
   }
   gates_m_inf = gates_m_forwardRate_r * (gates_m_forwardRate_r + gates_m_reverseRate_r)^-1
   gates_m_tau = (gates_m_forwardRate_r + gates_m_reverseRate_r)^-1
@@ -284,11 +278,7 @@ INITIAL {
   if (gates_m_forwardRate_x != 0) {
     gates_m_forwardRate_r = gates_m_forwardRate_x * (1 + -1 * exp(-1 * gates_m_forwardRate_x))^-1
   } else {
-    if (gates_m_forwardRate_x == 0) {
-      gates_m_forwardRate_r = 1
-    } else {
-      gates_m_forwardRate_r = 0
-    }
+    gates_m_forwardRate_r = 1
   }
   gates_m_inf = gates_m_forwardRate_r * (gates_m_forwardRate_r + gates_m_reverseRate_r)^-1
   gates_h_forwardRate_r = 0.07000000029802322 * exp(-0.05 * (65 + v))
@@ -306,11 +296,7 @@ DERIVATIVE dstate {
   if (gates_m_forwardRate_x != 0) {
     gates_m_forwardRate_r = gates_m_forwardRate_x * (1 + -1 * exp(-1 * gates_m_forwardRate_x))^-1
   } else {
-    if (gates_m_forwardRate_x == 0) {
-      gates_m_forwardRate_r = 1
-    } else {
-      gates_m_forwardRate_r = 0
-    }
+    gates_m_forwardRate_r = 1
   }
   gates_m_inf = gates_m_forwardRate_r * (gates_m_forwardRate_r + gates_m_reverseRate_r)^-1
   gates_m_tau = (gates_m_forwardRate_r + gates_m_reverseRate_r)^-1
@@ -465,11 +451,7 @@ INITIAL {
   if (gates_m_forwardRate_x != 0) {
     gates_m_forwardRate_r = gates_m_forwardRate_rate * gates_m_forwardRate_x * (1 + -1 * exp(-1 * gates_m_forwardRate_x))^-1
   } else {
-    if (gates_m_forwardRate_x == 0) {
-      gates_m_forwardRate_r = gates_m_forwardRate_rate
-    } else {
-      gates_m_forwardRate_r = 0
-    }
+    gates_m_forwardRate_r = gates_m_forwardRate_rate
   }
   gates_m_inf = gates_m_forwardRate_r * (gates_m_forwardRate_r + gates_m_reverseRate_r)^-1
   gates_h_forwardRate_r = gates_h_forwardRate_rate * exp((v + -1 * gates_h_forwardRate_midpoint) * gates_h_forwardRate_scale^-1)
@@ -487,11 +469,7 @@ DERIVATIVE dstate {
   if (gates_m_forwardRate_x != 0) {
     gates_m_forwardRate_r = gates_m_forwardRate_rate * gates_m_forwardRate_x * (1 + -1 * exp(-1 * gates_m_forwardRate_x))^-1
   } else {
-    if (gates_m_forwardRate_x == 0) {
-      gates_m_forwardRate_r = gates_m_forwardRate_rate
-    } else {
-      gates_m_forwardRate_r = 0
-    }
+    gates_m_forwardRate_r = gates_m_forwardRate_rate
   }
   gates_m_inf = gates_m_forwardRate_r * (gates_m_forwardRate_r + gates_m_reverseRate_r)^-1
   gates_m_tau = (gates_m_forwardRate_r + gates_m_reverseRate_r)^-1
@@ -517,3 +495,33 @@ BREAKPOINT {
 "#
     );
 }
+
+// #[test]
+// fn non_specific_ion_channel() {
+    // let lems = LemsFile::core();
+    // let tree = Document::parse(r#"<?xml version="1.0" encoding="UTF-8"?>
+// <neuroml xmlns="http://www.neuroml.org/schema/neuroml2"
+         // xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         // xsi:schemaLocation="http://www.neuroml.org/schema/neuroml2  ../Schemas/NeuroML2/NeuroML_v2beta4.xsd"
+         // id="NML2_SimpleIonChannel">
+    // <ionChannelHH id="NaConductance" conductance="10pS" species="na">
+        // <gateHHrates id="m" instances="1">
+            // <forwardRate type="HHExpLinearRate" rate="1per_ms" midpoint="-40mV" scale="10mV"/>
+            // <reverseRate type="HHExpRate" rate="4per_ms" midpoint="-65mV" scale="-18mV"/>
+        // </gateHHrates>
+    // </ionChannelHH>
+
+    // <ionChannelHH id="NaConductance" conductance="10pS" species="k">
+        // <gateHHrates id="m" instances="1">
+            // <forwardRate type="HHExpLinearRate" rate="1per_ms" midpoint="-40mV" scale="10mV"/>
+            // <reverseRate type="HHExpRate" rate="4per_ms" midpoint="-65mV" scale="-18mV"/>
+        // </gateHHrates>
+    // </ionChannelHH>
+// </neuroml>"#).unwrap();
+    // let node = tree
+        // .descendants()
+        // .find(|n| n.has_tag_name("ionChannelHH"))
+        // .unwrap();
+    // let inst = Instance::new(&lems, &node).unwrap();
+    // assert_eq!(to_nmodl(&inst, "-*", "baseIonChannel", &[]).unwrap(), r#""#);
+// }


### PR DESCRIPTION
- Start by enabling simplification on booleans.
- For generating a case-chain check whether the cumulative `or` of all case so far is `true`, if so, stop.

In sum, these changes remove redundant conditionals, example
```
x != 0 => y = 42
x == 0 => y = 23
default => y = 0
``` 
would generate
```
if (x !=0) {
  y = 42 
} else {
  if (x == 0) {
    y = 23
  } else {
    y = 0
  }
}
```
before, but since the final branch unreachable as $x \neq y \lor x = y$ is true $\forall x, y$
we get 
```
if (x !=0) {
  y = 42 
} else {
  y = 23
}
```