### PR TITLE
Allow duplicate morphology names

### DIFF
--- a/dat/main.py
+++ b/dat/main.py
@@ -59,7 +59,7 @@ class recipe(A.recipe):
     def cell_description(self, gid):
         cid = self.gid_to_cell[gid]
         mrf = self.cell_to_morph[cid]
-        nml = A.neuroml(f'{here}/mrf/{mrf}.nml').morphology(mrf, allow_spherical_root=True)
+        nml = A.neuroml(f'{here}/mrf/{cid}_{mrf}.nml').morphology(mrf, allow_spherical_root=True)
         lbl = A.label_dict()
         lbl.append(nml.segments())
         lbl.append(nml.named_segments())

--- a/src/bundle.rs
+++ b/src/bundle.rs
@@ -257,9 +257,15 @@ fn export_template(lems: &LemsFile, nml: &[String], bundle: &str) -> Result<()> 
         let doc = node.document().input_text();
         match node.tag_name().name() {
             "morphology" => {
-                let id = node
-                    .attribute("id")
-                    .ok_or_else(|| nml2_error!("Morph has no id"))?;
+                let cell = node
+                    .parent()
+                    .ok_or(nml2_error!("Morphology has no parent"))?;
+                if cell.tag_name().name() != "cell" {
+                    return Err(nml2_error!("Morphology must have cell as parent"));
+                }
+                let morph_id = node.attribute("id").ok_or(nml2_error!("Morph has no id"))?;
+                let cell_id = cell.attribute("id").ok_or(nml2_error!("Cell has no id"))?;
+                let id = &format!("{cell_id}_{morph_id}");
                 trace!("Writing morphology to {bundle}/mrf/{id}");
                 write(
                     format!("{bundle}/mrf/{id}.nml"),


### PR DESCRIPTION
For the CA1 example, we have multiple cells with id="morphology". Currently these all get overwritten and we end up with a single morphology.nml file. This PR fixes that.